### PR TITLE
Mqtt Actor fix and add support for tasmota sonoff

### DIFF
--- a/cbpi/extension/mqtt_actor/__init__.py
+++ b/cbpi/extension/mqtt_actor/__init__.py
@@ -1,45 +1,90 @@
 # -*- coding: utf-8 -*-
+
+# Topic pattern:
+# Tasmota on sonoff:
+# tasmota on sonoff TH16 or TH10 topic: cmnd/<tasmota_name_of _device>/Power
+# or like eg. cmnd/tasmota_F9713B/Power
+# Power in the meaning of on/off. Power as % is not supported
+# Have a look at https://stevessmarthomeguide.com/setting-up-the-sonoff-tasmota-mqtt-switch/
+# In Tasmota adjust configuration-> configure logging->Telemetry period (300) from 300s to 10s
+# to speed up the sensor (I know this is the actor section)
+# If you need to change payload please edit in function async def on(..) and async def off..)
+#
+# EspEasy
+# use this link:
+# https://nerdiy.de/howto-espeasy-mqtt-server-konfigurieren-und-topics-abonnieren/
+# You may use translate function of the browser to translate the language
+# If you need to change payload please edit in function async def on(..) and async def off..)
+
 import asyncio
+import logging
 import json
-from cbpi.api import parameters, Property, CBPiActor
 from cbpi.api import *
 
-@parameters([Property.Text(label="Topic", configurable=True, description = "MQTT Topic")])
+logger = logging.getLogger(__name__)
+
+
+@parameters([Property.Text(label="Topic", configurable=True, description="MQTT Topic"),
+             Property.Select(label="select_Mqtt_System", options=["default", "tasmota on sonoff THx", "ESPEasy"],
+                             description="different Mqtt Systems listen to different payloads")])
 class MQTTActor(CBPiActor):
 
-    # Custom property which can be configured by the user
-    @action("Set Power", parameters=[Property.Number(label="Power", configurable=True,description="Power Setting [0-100]")])
-    async def setpower(self,Power = 100 ,**kwargs):
-        self.power=round(Power)
+    @action("Set Power",
+            parameters=[Property.Number(label="Power", configurable=True, description="Power Setting [0-100]")])
+    async def setpower(self, Power=100, **kwargs):
+        self.power = int(Power)
         if self.power < 0:
             self.power = 0
         if self.power > 100:
-            self.power = 100           
-        await self.set_power(self.power)      
+            self.power = 100
+        await self.set_power(self.power)
 
     def __init__(self, cbpi, id, props):
         super(MQTTActor, self).__init__(cbpi, id, props)
 
     async def on_start(self):
-         self.topic = self.props.get("Topic", None)
-         self.power = 100
+        self.topic = self.props.get("Topic", None)
+        self.mqtt_select = self.props.get("select_Mqtt_System", None)
+        if self.mqtt_select is None:
+            self.mqtt_select = "default"
+        pass
+
+        self.power = 100
+        logger.info("Mqtt started")
 
     async def on(self, power=None):
         if power is not None:
             if power != self.power:
                 power = min(100, power)
                 power = max(0, power)
-                self.power = round(power)
-        await self.cbpi.satellite.publish(self.topic, json.dumps(
-            {"state": "on", "power": self.power}), True)
-        self.state = True
+                self.power = int(power)
+        else:
+            # just to be safe
+            self.power = 0
+
+        if self.mqtt_select == "default":
+            await self.cbpi.satellite.publish(self.topic, json.dumps({"state": "on", "power": self.power}), True)
+        elif self.mqtt_select == "tasmota on sonoff THx":
+            await self.cbpi.satellite.publish(self.topic, "on", True)
+        elif self.mqtt_select == "ESPEasy":
+            await self.cbpi.satellite.publish(self.topic, 1, True)
+        else:
+            logger.error("MQTT on: no Mqtt System selected")
         pass
+        self.state = True
 
     async def off(self):
         self.state = False
-        await self.cbpi.satellite.publish(self.topic, json.dumps(
-            {"state": "off", "power": self.power}), True)
-        pass
+
+        if self.mqtt_select == "default":
+            await self.cbpi.satellite.publish(self.topic, json.dumps({"state": "off", "power": self.power}), True)
+        elif self.mqtt_select == "tasmota on sonoff THx":
+            await self.cbpi.satellite.publish(self.topic, "off", True)
+        elif self.mqtt_select == "ESPEasy":
+            await self.cbpi.satellite.publish(self.topic, 0, True)
+        else:
+            logger.error("MQTT off: no Mqtt System selected")
+            pass
 
     async def run(self):
         while self.running:
@@ -49,13 +94,14 @@ class MQTTActor(CBPiActor):
         return self.state
 
     async def set_power(self, power):
-        self.power = round(power)
-        if self.state == True:
+        self.power = int(power)
+        if self.state is True:
             await self.on(power)
         else:
             await self.off()
-        await self.cbpi.actor.actor_update(self.id,power)
+        await self.cbpi.actor.actor_update(self.id, power)
         pass
+
 
 def setup(cbpi):
     '''


### PR DESCRIPTION
There was an error when the performance was changed. I've replaced round () with int (). Now the percentage of the performance is displayed on the icon of the actor.
Added support for Sonoff flashed with Tasmota.
Payload for ESPEasy added. But I couldn't test it. The same with the original payload used by alexander. I can't test it.
I tested whether changing configurations lead to errors. But I cannot test the functionality. Sonoff is of course tested